### PR TITLE
Active by mutable reference

### DIFF
--- a/examples/shadow-map/main.rs
+++ b/examples/shadow-map/main.rs
@@ -545,7 +545,7 @@ impl Window {
             .bind(&vao)
             .attribute(
                 // Read from our vertex buffer,
-                &vbo,
+                vbo,
                 // Vertex shader location zero,
                 0,
                 vertex_array::Attribute {
@@ -562,7 +562,7 @@ impl Window {
             )
             .attribute(
                 // Again, for the normals.
-                &vbo,
+                vbo,
                 1,
                 vertex_array::Attribute {
                     components: vertex_array::Components::Vec3,

--- a/examples/shadow-map/main.rs
+++ b/examples/shadow-map/main.rs
@@ -520,9 +520,7 @@ impl Window {
         let [vertex_buffer, index_buffer] = gl.new.buffers();
 
         // Bulk upload our scene data
-        let vbo = gl.buffer.array.bind(&vertex_buffer);
-        // Vertex arrays, containing both position and normals interleaved.
-        vbo.data(
+        let vbo = gl.buffer.array.bind(&vertex_buffer).data(
             bytemuck::cast_slice(&vertices),
             glhf::buffer::usage::Frequency::Static,
             glhf::buffer::usage::Access::Draw,
@@ -632,22 +630,24 @@ impl Window {
         // Bind the index buffer and the vertex array, which contains references to our vertex buffer.
         let elements = gl.buffer.element_array.bind(&self.index_buffer);
         let vertex_array = gl.vertex_array.bind(&self.vao);
-        // Bind the shadow framebuffer and the shadow program.
-        let framebuffer = gl.framebuffer.draw.bind_complete(&self.shadow_framebuffer);
+        // Bind the shadow framebuffer, cleared, and the shadow program.
+        let framebuffer = gl
+            .framebuffer
+            .draw
+            .bind_complete(&self.shadow_framebuffer)
+            .clear(glhf::slot::framebuffer::AspectMask::DEPTH);
         let program = gl.program.bind(&self.shadow_program);
-        // Clear the depth buffer.
-        framebuffer.clear(glhf::slot::framebuffer::AspectMask::DEPTH);
 
         // Provide static proof-of-state to the `draw.elements` call.
         let draw_info = glhf::draw::ElementState {
             // We have an element buffer bound...
-            elements: &elements,
+            elements,
             // ...a complete framebuffer...
-            framebuffer: &framebuffer,
+            framebuffer,
             // ...a linked program...
-            program: &program,
+            program,
             // ...and a vertex array!
-            vertex_array: &vertex_array,
+            vertex_array,
         };
         unsafe {
             // Draw our indexed mesh.
@@ -660,10 +660,13 @@ impl Window {
             )
         };
 
-        // Switch to the "default" framebuffer, which is the window surface.
-        let framebuffer = gl.framebuffer.draw.bind_default();
+        // Switch to the "default" framebuffer, which is the window surface,
         // Clear it and it's depth-bufffer.
-        framebuffer.clear(glhf::slot::framebuffer::AspectMask::all());
+        let framebuffer = gl
+            .framebuffer
+            .draw
+            .bind_default()
+            .clear(glhf::slot::framebuffer::AspectMask::all());
 
         // Use the program that samples our shadow mask and calculates lighting.
         let program = gl.program.bind(&self.program);
@@ -677,10 +680,10 @@ impl Window {
 
         // And draw again!
         let draw_info = glhf::draw::ElementState {
-            elements: &elements,
-            framebuffer: &framebuffer,
-            program: &program,
-            vertex_array: &vertex_array,
+            elements,
+            framebuffer,
+            program,
+            vertex_array,
         };
         unsafe {
             gl.draw.elements(

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -10,16 +10,11 @@
 
 use crate::slot::{self, marker};
 
-type ActiveProgram<'a> = slot::program::Active<'a, marker::NotDefault>;
-type ActiveVertexArray<'a> = slot::vertex_array::Active<'a, marker::NotDefault>;
-type ActiveElementArray<'a> =
-    slot::buffer::Active<'a, slot::buffer::ElementArray, marker::NotDefault>;
-type ActiveDrawFramebuffer<'a, Defaultness> = slot::framebuffer::Active<
-    'a,
-    slot::framebuffer::Draw,
-    Defaultness,
-    crate::framebuffer::Complete,
->;
+type ActiveProgram = slot::program::Active<marker::NotDefault>;
+type ActiveVertexArray = slot::vertex_array::Active<marker::NotDefault>;
+type ActiveElementArray = slot::buffer::Active<slot::buffer::ElementArray, marker::NotDefault>;
+type ActiveDrawFramebuffer<Defaultness> =
+    slot::framebuffer::Active<slot::framebuffer::Draw, Defaultness, crate::framebuffer::Complete>;
 
 use super::{gl, GLEnum, NotSync};
 
@@ -60,23 +55,23 @@ impl ElementType {
 #[derive(Copy, Clone)]
 pub struct ArrayState<'a, Default: marker::Defaultness> {
     /// Static proof that a non-null Vertex Array is bound.
-    pub vertex_array: &'a ActiveVertexArray<'a>,
+    pub vertex_array: &'a ActiveVertexArray,
     /// Static proof that a Complete framebuffer is bound.
-    pub framebuffer: &'a ActiveDrawFramebuffer<'a, Default>,
+    pub framebuffer: &'a ActiveDrawFramebuffer<Default>,
     /// Static proof that a successfully-linked program is bound.
-    pub program: &'a ActiveProgram<'a>,
+    pub program: &'a ActiveProgram,
 }
 
 #[derive(Copy, Clone)]
 pub struct ElementState<'a, Default: marker::Defaultness> {
     /// Static proof that a non-null Element Array is bound.
-    pub elements: &'a ActiveElementArray<'a>,
+    pub elements: &'a ActiveElementArray,
     /// Static proof that a non-null Vertex Array is bound.
-    pub vertex_array: &'a ActiveVertexArray<'a>,
+    pub vertex_array: &'a ActiveVertexArray,
     /// Static proof that a Complete framebuffer is bound.
-    pub framebuffer: &'a ActiveDrawFramebuffer<'a, Default>,
+    pub framebuffer: &'a ActiveDrawFramebuffer<Default>,
     /// Static proof that a successfully-linked program is bound.
-    pub program: &'a ActiveProgram<'a>,
+    pub program: &'a ActiveProgram,
 }
 
 /// Bindings to `glDraw*`

--- a/src/slot/buffer.rs
+++ b/src/slot/buffer.rs
@@ -302,26 +302,26 @@ pub struct Slot<Binding: Target>(
 impl<Binding: Target> Slot<Binding> {
     /// Bind a buffer to this slot.
     #[doc(alias = "glBindBuffer")]
-    pub fn bind(&mut self, buffer: &Buffer) -> Active<Binding, NotDefault> {
+    pub fn bind(&mut self, buffer: &Buffer) -> &mut Active<Binding, NotDefault> {
         unsafe {
             gl::BindBuffer(Binding::TARGET, buffer.name().get());
         }
-        Active(std::marker::PhantomData, std::marker::PhantomData)
+        super::zst_mut()
     }
     /// Make the slot empty.
     #[doc(alias = "glBindBuffer")]
-    pub fn unbind(&mut self) -> Active<Binding, IsDefault> {
+    pub fn unbind(&mut self) -> &mut Active<Binding, IsDefault> {
         unsafe {
             gl::BindBuffer(Binding::TARGET, 0);
         }
-        Active(std::marker::PhantomData, std::marker::PhantomData)
+        super::zst_mut()
     }
     /// Inherit the currently bound buffer - this may be no buffer at all.
     ///
     /// Most functionality is limited when the status of the buffer (`Default` or `NotDefault`) is not known.
     #[must_use]
-    pub fn inherit(&self) -> Active<Binding, Unknown> {
-        Active(std::marker::PhantomData, std::marker::PhantomData)
+    pub fn inherit(&self) -> &Active<Binding, Unknown> {
+        super::zst_ref()
     }
 }
 

--- a/src/slot/framebuffer.rs
+++ b/src/slot/framebuffer.rs
@@ -79,7 +79,12 @@ pub struct Active<'slot, Slot, Default: Defaultness, Completeness>(
 
 impl<T: Target> Active<'_, T, NotDefault, Incomplete> {
     #[doc(alias = "glFramebufferTexture2D")]
-    pub fn texture_2d(&self, texture: &Texture2D, attachment: Attachment, mip_level: u32) -> &Self {
+    pub fn texture_2d(
+        &mut self,
+        texture: &Texture2D,
+        attachment: Attachment,
+        mip_level: u32,
+    ) -> &mut Self {
         unsafe {
             gl::FramebufferTexture2D(
                 T::TARGET,
@@ -104,10 +109,10 @@ impl<AnyDefaultness: Defaultness> Active<'_, Draw, AnyDefaultness, Complete> {
     /// and destination rectangles overlap, behavior is undefined.
     #[doc(alias = "glBlitFramebuffer")]
     pub unsafe fn blit_from<OtherDefaultness: Defaultness>(
-        &self,
+        &mut self,
         _from: &Active<Read, OtherDefaultness, Complete>,
         info: &BlitInfo,
-    ) -> &Self {
+    ) -> &mut Self {
         if info.mask.is_empty() {
             return self;
         }
@@ -137,7 +142,7 @@ impl<AnyDefaultness: Defaultness> Active<'_, Draw, AnyDefaultness, Complete> {
     ///
     /// The clear values are inherited from the global values `ClearColor`, `ClearDepth`, and `ClearStencil`.
     #[doc(alias = "glClear")]
-    pub fn clear(&self, mask: AspectMask) -> &Self {
+    pub fn clear(&mut self, mask: AspectMask) -> &mut Self {
         if mask.is_empty() {
             return self;
         }
@@ -156,7 +161,7 @@ impl<AnyDefaultness: Defaultness> Active<'_, Read, AnyDefaultness, Complete> {
     #[doc(alias = "glBlitFramebuffer")]
     pub unsafe fn blit_to<OtherDefaultness: Defaultness>(
         &self,
-        other: &Active<'_, Draw, OtherDefaultness, Complete>,
+        other: &mut Active<'_, Draw, OtherDefaultness, Complete>,
         info: &BlitInfo,
     ) -> &Self {
         other.blit_from(self, info);
@@ -176,7 +181,7 @@ impl<AnyDefaultness: Defaultness> Active<'_, Read, AnyDefaultness, Complete> {
     #[doc(alias = "glCopyTexSubImage2D")]
     pub unsafe fn copy_subimage_to(
         &self,
-        _to: &crate::slot::texture::Active<'_, crate::texture::D2>,
+        _to: &mut crate::slot::texture::Active<'_, crate::texture::D2>,
         level: u32,
         // Intentionally signed. It is not UB to read beyond the buffer, but it is UB to access those values read.
         // This may still be useful, idk X3
@@ -212,7 +217,7 @@ impl<AnyDefaultness: Defaultness> Active<'_, Read, AnyDefaultness, Complete> {
     #[doc(alias = "glCopyTexImage2D")]
     pub unsafe fn copy_image_to(
         &self,
-        _to: &crate::slot::texture::Active<'_, crate::texture::D2>,
+        _to: &mut crate::slot::texture::Active<'_, crate::texture::D2>,
         level: u32,
         // Fixme: this actually only accepts a subset of this enum.
         internal_format: crate::texture::InternalFormat,
@@ -245,7 +250,7 @@ impl<AnyCompleteness> Active<'_, Draw, NotDefault, AnyCompleteness> {
     /// # Panics
     /// Every element of `buffers` must be either none or a unique value.
     #[doc(alias = "glDrawBuffers")]
-    pub fn draw_buffers(&self, buffers: &[Buffer]) -> &Self {
+    pub fn draw_buffers(&mut self, buffers: &[Buffer]) -> &mut Self {
         assert!(is_all_unique(buffers));
         // Cast safety: Fieldless repr(u32), can be safely reinterpreted as &[u32]
         unsafe { gl::DrawBuffers(buffers.len().try_into().unwrap(), buffers.as_ptr().cast()) }
@@ -261,7 +266,7 @@ impl Active<'_, Draw, IsDefault, Complete> {
     /// # Panics
     /// Every element of `buffers` must be either none or a unique value.
     #[doc(alias = "glDrawBuffers")]
-    pub fn draw_buffers(&self, buffers: &[DefaultBuffer]) -> &Self {
+    pub fn draw_buffers(&mut self, buffers: &[DefaultBuffer]) -> &mut Self {
         assert!(is_all_unique(buffers));
         // Cast safety: Fieldless repr(u32), can be safely reinterpreted as &[u32]
         unsafe { gl::DrawBuffers(buffers.len().try_into().unwrap(), buffers.as_ptr().cast()) }
@@ -272,7 +277,7 @@ impl Active<'_, Draw, IsDefault, Complete> {
 impl<AnyCompleteness> Active<'_, Read, NotDefault, AnyCompleteness> {
     /// Set the source for pixel read operations.
     #[doc(alias = "glReadBuffer")]
-    pub fn read_buffer(&self, buffer: Buffer) -> &Self {
+    pub fn read_buffer(&mut self, buffer: Buffer) -> &mut Self {
         unsafe { gl::ReadBuffer(buffer.as_gl()) }
         self
     }
@@ -281,7 +286,7 @@ impl<AnyCompleteness> Active<'_, Read, NotDefault, AnyCompleteness> {
 impl Active<'_, Draw, IsDefault, Complete> {
     /// Set the source for pixel read operations.
     #[doc(alias = "glReadBuffer")]
-    pub fn read_buffer(&self, buffer: DefaultBuffer) -> &Self {
+    pub fn read_buffer(&mut self, buffer: DefaultBuffer) -> &mut Self {
         unsafe { gl::ReadBuffer(buffer.as_gl()) }
         self
     }
@@ -292,7 +297,7 @@ impl Active<'_, Draw, IsDefault, Complete> {
 pub struct IncompleteError<'slot, Slot> {
     /// The activation token of the framebuffer. Even if it failed to pass completion,
     /// it is bound.
-    pub active: Active<'slot, Slot, NotDefault, Incomplete>,
+    pub active: &'slot mut Active<'slot, Slot, NotDefault, Incomplete>,
     /// Returns ownership of the framebuffer.
     pub framebuffer: Incomplete,
     pub kind: IncompleteErrorKind,
@@ -340,19 +345,22 @@ pub struct Slot<T: Target>(pub(crate) NotSync, pub(crate) std::marker::PhantomDa
 impl<T: Target> Slot<T> {
     /// Bind a user-defined framebuffer to this slot.
     #[doc(alias = "glBindFramebuffer")]
-    pub fn bind(&mut self, framebuffer: &Incomplete) -> Active<T, NotDefault, Incomplete> {
+    pub fn bind(&mut self, framebuffer: &Incomplete) -> &mut Active<T, NotDefault, Incomplete> {
         unsafe {
             gl::BindFramebuffer(T::TARGET, framebuffer.0.get());
         }
-        Active(std::marker::PhantomData, std::marker::PhantomData)
+        super::zst_mut()
     }
     /// Bind a user-defined framebuffer to this slot.
     #[doc(alias = "glBindFramebuffer")]
-    pub fn bind_complete(&mut self, framebuffer: &Complete) -> Active<T, NotDefault, Complete> {
+    pub fn bind_complete(
+        &mut self,
+        framebuffer: &Complete,
+    ) -> &mut Active<T, NotDefault, Complete> {
         unsafe {
             gl::BindFramebuffer(T::TARGET, framebuffer.0.get());
         }
-        Active(std::marker::PhantomData, std::marker::PhantomData)
+        super::zst_mut()
     }
     /// Check completeness of the given framebuffer, binding it in the process.
     ///
@@ -362,14 +370,14 @@ impl<T: Target> Slot<T> {
     pub fn try_complete(
         &mut self,
         framebuffer: Incomplete,
-    ) -> Result<(Complete, Active<T, NotDefault, Complete>), IncompleteError<T>> {
+    ) -> Result<(Complete, &mut Active<T, NotDefault, Complete>), IncompleteError<T>> {
         let active = self.bind(&framebuffer);
         let status = unsafe { gl::CheckFramebufferStatus(T::TARGET) };
         if status == gl::FRAMEBUFFER_COMPLETE {
             Ok((
                 // Safety - we just checked, dummy!
                 unsafe { framebuffer.into_complete_unchecked() },
-                Active(std::marker::PhantomData, std::marker::PhantomData),
+                super::zst_mut(),
             ))
         } else {
             Err(IncompleteError {
@@ -381,18 +389,25 @@ impl<T: Target> Slot<T> {
     }
     /// Bind the default framebuffer, 0, to this slot.
     #[doc(alias = "glBindFramebuffer")]
-    pub fn bind_default(&mut self) -> Active<T, IsDefault, Complete> {
+    pub fn bind_default(&mut self) -> &mut Active<T, IsDefault, Complete> {
         unsafe {
             gl::BindFramebuffer(T::TARGET, 0);
         }
-        Active(std::marker::PhantomData, std::marker::PhantomData)
+        super::zst_mut()
     }
     /// Inherit the currently bound framebuffer. This may be the default framebuffer.
     ///
     /// Some functionality is limited when the type of framebuffer (`Default` or `NotDefault`) is not known.
     #[must_use]
-    pub fn inherit(&self) -> Active<T, Unknown, Unknown> {
-        Active(std::marker::PhantomData, std::marker::PhantomData)
+    pub fn inherit(&self) -> &Active<T, Unknown, Unknown> {
+        super::zst_ref()
+    }
+    /// Inherit the currently bound framebuffer. This may be the default framebuffer.
+    ///
+    /// Some functionality is limited when the type of framebuffer (`Default` or `NotDefault`) is not known.
+    #[must_use]
+    pub fn inherit_mut(&mut self) -> &mut Active<T, Unknown, Unknown> {
+        super::zst_mut()
     }
 }
 
@@ -409,16 +424,13 @@ impl Slots {
         &mut self,
         framebuffer: &Incomplete,
     ) -> (
-        Active<Read, NotDefault, Incomplete>,
-        Active<Draw, NotDefault, Incomplete>,
+        &mut Active<Read, NotDefault, Incomplete>,
+        &mut Active<Draw, NotDefault, Incomplete>,
     ) {
         unsafe {
             gl::BindFramebuffer(gl::FRAMEBUFFER, framebuffer.0.get());
         }
-        (
-            Active(std::marker::PhantomData, std::marker::PhantomData),
-            Active(std::marker::PhantomData, std::marker::PhantomData),
-        )
+        (super::zst_mut(), super::zst_mut())
     }
     /// Bind a framebuffer to both the read and the draw slots.
     ///
@@ -428,16 +440,13 @@ impl Slots {
         &mut self,
         framebuffer: &Complete,
     ) -> (
-        Active<Read, NotDefault, Complete>,
-        Active<Draw, NotDefault, Complete>,
+        &mut Active<Read, NotDefault, Complete>,
+        &mut Active<Draw, NotDefault, Complete>,
     ) {
         unsafe {
             gl::BindFramebuffer(gl::FRAMEBUFFER, framebuffer.0.get());
         }
-        (
-            Active(std::marker::PhantomData, std::marker::PhantomData),
-            Active(std::marker::PhantomData, std::marker::PhantomData),
-        )
+        (super::zst_mut(), super::zst_mut())
     }
     /// Bind the default framebuffer to both the read and the draw slots.
     ///
@@ -446,16 +455,13 @@ impl Slots {
     pub fn bind_default(
         &mut self,
     ) -> (
-        Active<Read, IsDefault, Complete>,
-        Active<Draw, IsDefault, Complete>,
+        &mut Active<Read, IsDefault, Complete>,
+        &mut Active<Draw, IsDefault, Complete>,
     ) {
         unsafe {
             gl::BindFramebuffer(gl::FRAMEBUFFER, 0);
         }
-        (
-            Active(std::marker::PhantomData, std::marker::PhantomData),
-            Active(std::marker::PhantomData, std::marker::PhantomData),
-        )
+        (super::zst_mut(), super::zst_mut())
     }
     /// Delete framebuffers. If any were bound to a slot, the slot becomes bound to the default framebuffer.
     ///

--- a/src/slot/framebuffer.rs
+++ b/src/slot/framebuffer.rs
@@ -72,12 +72,11 @@ pub struct BlitInfo {
 
 /// Entry points for `glFramebuffer*`
 #[derive(Debug)]
-pub struct Active<'slot, Slot, Default: Defaultness, Completeness>(
-    std::marker::PhantomData<&'slot ()>,
+pub struct Active<Slot, Default: Defaultness, Completeness>(
     std::marker::PhantomData<(Default, Slot, Completeness)>,
 );
 
-impl<T: Target> Active<'_, T, NotDefault, Incomplete> {
+impl<T: Target> Active<T, NotDefault, Incomplete> {
     #[doc(alias = "glFramebufferTexture2D")]
     pub fn texture_2d(
         &mut self,
@@ -98,7 +97,7 @@ impl<T: Target> Active<'_, T, NotDefault, Incomplete> {
     }
 }
 
-impl<AnyDefaultness: Defaultness> Active<'_, Draw, AnyDefaultness, Complete> {
+impl<AnyDefaultness: Defaultness> Active<Draw, AnyDefaultness, Complete> {
     /// Blit data from the read buffer into this buffer.
     ///
     /// The read buffer's current color attachment ([`Active::read_buffer`]) is copied
@@ -152,7 +151,7 @@ impl<AnyDefaultness: Defaultness> Active<'_, Draw, AnyDefaultness, Complete> {
         self
     }
 }
-impl<AnyDefaultness: Defaultness> Active<'_, Read, AnyDefaultness, Complete> {
+impl<AnyDefaultness: Defaultness> Active<Read, AnyDefaultness, Complete> {
     /// Blit data from this buffer into the write buffer.
     ///
     /// This is the reverse of [Active<'_, Draw, OtherDefaultness, Complete>::blit_from],
@@ -161,7 +160,7 @@ impl<AnyDefaultness: Defaultness> Active<'_, Read, AnyDefaultness, Complete> {
     #[doc(alias = "glBlitFramebuffer")]
     pub unsafe fn blit_to<OtherDefaultness: Defaultness>(
         &self,
-        other: &mut Active<'_, Draw, OtherDefaultness, Complete>,
+        other: &mut Active<Draw, OtherDefaultness, Complete>,
         info: &BlitInfo,
     ) -> &Self {
         other.blit_from(self, info);
@@ -242,7 +241,7 @@ impl<AnyDefaultness: Defaultness> Active<'_, Read, AnyDefaultness, Complete> {
     }
 }
 
-impl<AnyCompleteness> Active<'_, Draw, NotDefault, AnyCompleteness> {
+impl<AnyCompleteness> Active<Draw, NotDefault, AnyCompleteness> {
     /// Direct fragment outputs into appropriate buffers.
     /// I.e., Fragment output 0 will go into the buffer defined by `buffers[0]`.
     /// If the slice is too short, remaining slots default to [`Buffer::None`]
@@ -258,7 +257,7 @@ impl<AnyCompleteness> Active<'_, Draw, NotDefault, AnyCompleteness> {
     }
 }
 
-impl Active<'_, Draw, IsDefault, Complete> {
+impl Active<Draw, IsDefault, Complete> {
     /// Direct fragment outputs into appropriate buffers.
     /// I.e., Fragment output 0 will go into the buffer defined by `buffers[0]`.
     /// If the slice is too short, remaining slots default to [`DefaultBuffer::None`]
@@ -274,7 +273,7 @@ impl Active<'_, Draw, IsDefault, Complete> {
     }
 }
 
-impl<AnyCompleteness> Active<'_, Read, NotDefault, AnyCompleteness> {
+impl<AnyCompleteness> Active<Read, NotDefault, AnyCompleteness> {
     /// Set the source for pixel read operations.
     #[doc(alias = "glReadBuffer")]
     pub fn read_buffer(&mut self, buffer: Buffer) -> &mut Self {
@@ -283,7 +282,7 @@ impl<AnyCompleteness> Active<'_, Read, NotDefault, AnyCompleteness> {
     }
 }
 
-impl Active<'_, Draw, IsDefault, Complete> {
+impl Active<Draw, IsDefault, Complete> {
     /// Set the source for pixel read operations.
     #[doc(alias = "glReadBuffer")]
     pub fn read_buffer(&mut self, buffer: DefaultBuffer) -> &mut Self {
@@ -297,7 +296,7 @@ impl Active<'_, Draw, IsDefault, Complete> {
 pub struct IncompleteError<'slot, Slot> {
     /// The activation token of the framebuffer. Even if it failed to pass completion,
     /// it is bound.
-    pub active: &'slot mut Active<'slot, Slot, NotDefault, Incomplete>,
+    pub active: &'slot mut Active<Slot, NotDefault, Incomplete>,
     /// Returns ownership of the framebuffer.
     pub framebuffer: Incomplete,
     pub kind: IncompleteErrorKind,

--- a/src/slot/mod.rs
+++ b/src/slot/mod.rs
@@ -7,3 +7,28 @@ pub mod framebuffer;
 pub mod program;
 pub mod texture;
 pub mod vertex_array;
+
+/// create a reference to a ZST out of thin air for the given lifetime
+fn zst_mut<'a, T>() -> &'a mut T {
+    const {
+        assert!(std::mem::size_of::<T>() == 0);
+    };
+
+    // Use an arbitrary pointer. ZSTs do not require a valid allocated object,
+    // but they *do* require a valid (well-aligned and non-null) address.
+    let mut dummy_ptr = std::ptr::NonNull::<T>::dangling();
+
+    unsafe { dummy_ptr.as_mut() }
+}
+/// create a reference to a ZST out of thin air for the given lifetime
+fn zst_ref<'a, T>() -> &'a T {
+    const {
+        assert!(std::mem::size_of::<T>() == 0);
+    };
+
+    // Use an arbitrary pointer. ZSTs do not require a valid allocated object,
+    // but they *do* require a valid (well-aligned and non-null) address.
+    let dummy_ptr = std::ptr::NonNull::<T>::dangling();
+
+    unsafe { dummy_ptr.as_ref() }
+}

--- a/src/slot/program.rs
+++ b/src/slot/program.rs
@@ -95,10 +95,10 @@ impl Active<'_, NotDefault> {
         T: program::uniform::Value,
         Value: Into<program::uniform::Vector<'tiny, T>>,
     >(
-        &self,
+        &mut self,
         base_location: u32,
         value: Value,
-    ) -> &Self {
+    ) -> &mut Self {
         use program::uniform::{Ty, Vector};
 
         let value = value.into();
@@ -177,10 +177,10 @@ impl Active<'_, NotDefault> {
     #[doc(alias = "glUniformMatrix3x4fv")]
     #[doc(alias = "glUniformMatrix4x3fv")]
     pub fn uniform_matrix<'tiny>(
-        &self,
+        &mut self,
         base_location: u32,
         value: impl Into<program::uniform::Matrix<'tiny>>,
-    ) -> &Self {
+    ) -> &mut Self {
         use program::uniform::Matrix;
         let value = value.into();
 
@@ -270,19 +270,19 @@ pub struct Slot(pub(crate) NotSync);
 impl Slot {
     /// `glUse` a linked program.
     #[doc(alias = "glUseProgram")]
-    pub fn bind(&mut self, program: &LinkedProgram) -> Active<NotDefault> {
+    pub fn bind(&mut self, program: &LinkedProgram) -> &mut Active<NotDefault> {
         unsafe {
             gl::UseProgram(program.name().get());
         }
-        Active(std::marker::PhantomData, std::marker::PhantomData)
+        super::zst_mut()
     }
     /// Make the used program slot empty.
     #[doc(alias = "glUseProgram")]
-    pub fn unbind(&mut self) -> Active<IsDefault> {
+    pub fn unbind(&mut self) -> &mut Active<IsDefault> {
         unsafe {
             gl::UseProgram(0);
         }
-        Active(std::marker::PhantomData, std::marker::PhantomData)
+        super::zst_mut()
     }
     /// Set the GLSL ES source code of a shader, then attempt to compile it.
     // Is there a usecase for allowing each step of this process manually...?
@@ -363,8 +363,15 @@ impl Slot {
     ///
     /// Most functionality is limited when the status of the program (`Empty` or `NotEmpty`) is not known.
     #[must_use]
-    pub fn inherit(&self) -> Active<Unknown> {
-        Active(std::marker::PhantomData, std::marker::PhantomData)
+    pub fn inherit(&self) -> &Active<Unknown> {
+        super::zst_ref()
+    }
+    /// Inherit the currently bound program - this may be no program at all.
+    ///
+    /// Most functionality is limited when the status of the program (`Empty` or `NotEmpty`) is not known.
+    #[must_use]
+    pub fn inherit_mut(&mut self) -> &mut Active<Unknown> {
+        super::zst_mut()
     }
     /// Delete a program. If the program is currently bound to the slot, it remains so
     /// and will be deleted at the moment it is no longer bound.

--- a/src/slot/program.rs
+++ b/src/slot/program.rs
@@ -60,7 +60,7 @@ pub struct LinkError {
     pub error: std::ffi::CString,
 }
 
-impl Active<'_, NotDefault> {
+impl Active<NotDefault> {
     /// Starting at `base_location`, bind one (or an array) of uniform scalars or vectors.
     /// The value may only be an array if it was declared as an array within the shader.
     ///
@@ -262,10 +262,7 @@ impl Active<'_, NotDefault> {
 }
 
 /// Entry points for working with `glUse`d programs.
-pub struct Active<'slot, Kind>(
-    std::marker::PhantomData<&'slot ()>,
-    std::marker::PhantomData<Kind>,
-);
+pub struct Active<Kind>(std::marker::PhantomData<Kind>);
 pub struct Slot(pub(crate) NotSync);
 impl Slot {
     /// `glUse` a linked program.

--- a/src/slot/vertex_array.rs
+++ b/src/slot/vertex_array.rs
@@ -26,12 +26,12 @@ impl Active<'_, NotDefault> {
     #[doc(alias = "glVertexAttribPointer")]
     #[doc(alias = "glVertexAttribIPointer")]
     pub fn attribute(
-        &self,
+        &mut self,
         _source: &super::buffer::Active<'_, super::buffer::Array, NotDefault>,
         index: u32,
         attribute: vertex_array::Attribute,
         enable: Option<bool>,
-    ) -> &Self {
+    ) -> &mut Self {
         use vertex_array::AttributeType;
         let size = attribute.components.into();
         let stride = attribute
@@ -91,7 +91,7 @@ impl Active<'_, NotDefault> {
     /// Enable or disable the attribute at `index`. By default, all attributes are disabled.
     #[doc(alias = "glEnableVertexAttribArray")]
     #[doc(alias = "glDisableVertexAttribArray")]
-    pub fn set_attribute_enabled(&self, index: u32, enabled: bool) -> &Self {
+    pub fn set_attribute_enabled(&mut self, index: u32, enabled: bool) -> &mut Self {
         if enabled {
             unsafe {
                 gl::EnableVertexAttribArray(index);
@@ -114,26 +114,33 @@ pub struct Slot(pub(crate) NotSync);
 impl Slot {
     /// Bind a user-defined array to this slot.
     #[doc(alias = "glBindVertexArray")]
-    pub fn bind(&mut self, array: &VertexArray) -> Active<NotDefault> {
+    pub fn bind(&mut self, array: &VertexArray) -> &mut Active<NotDefault> {
         unsafe {
             gl::BindVertexArray(array.name().get());
         }
-        Active(std::marker::PhantomData, std::marker::PhantomData)
+        super::zst_mut()
     }
     /// Make the slot empty.
     #[doc(alias = "glBindVertexArray")]
-    pub fn unbind(&mut self) -> Active<IsDefault> {
+    pub fn unbind(&mut self) -> &mut Active<IsDefault> {
         unsafe {
             gl::BindVertexArray(0);
         }
-        Active(std::marker::PhantomData, std::marker::PhantomData)
+        super::zst_mut()
     }
     /// Inherit the currently bound array - this may be no array at all.
     ///
     /// Most functionality is limited when the status of the array (`Empty` or `NotEmpty`) is not known.
     #[must_use]
-    pub fn inherit(&self) -> Active<Unknown> {
-        Active(std::marker::PhantomData, std::marker::PhantomData)
+    pub fn inherit(&self) -> &Active<Unknown> {
+        super::zst_ref()
+    }
+    /// Inherit the currently bound array - this may be no array at all.
+    ///
+    /// Most functionality is limited when the status of the array (`Empty` or `NotEmpty`) is not known.
+    #[must_use]
+    pub fn inherit_mut(&mut self) -> &mut Active<Unknown> {
+        super::zst_mut()
     }
     /// Delete vertex arrays. If any were bound to this slot, the slot becomes unbound.
     #[doc(alias = "glDeleteVertexArrays")]

--- a/src/slot/vertex_array.rs
+++ b/src/slot/vertex_array.rs
@@ -10,7 +10,7 @@ use crate::{
 // client pointers could be bound to object 0, yikes! We don't do this, and
 // instead treat object 0 as null.
 
-impl Active<'_, NotDefault> {
+impl Active<NotDefault> {
     /// Set the properties of a vertex attribute slot. The source buffer is remembered
     /// internally, and does not need to be active at time of draw.
     ///
@@ -27,7 +27,7 @@ impl Active<'_, NotDefault> {
     #[doc(alias = "glVertexAttribIPointer")]
     pub fn attribute(
         &mut self,
-        _source: &super::buffer::Active<'_, super::buffer::Array, NotDefault>,
+        _source: &super::buffer::Active<super::buffer::Array, NotDefault>,
         index: u32,
         attribute: vertex_array::Attribute,
         enable: Option<bool>,
@@ -106,10 +106,7 @@ impl Active<'_, NotDefault> {
 }
 
 /// Entry points for `gl*VertexAttrib*`.
-pub struct Active<'slot, Kind>(
-    std::marker::PhantomData<&'slot ()>,
-    std::marker::PhantomData<Kind>,
-);
+pub struct Active<Kind>(std::marker::PhantomData<Kind>);
 pub struct Slot(pub(crate) NotSync);
 impl Slot {
     /// Bind a user-defined array to this slot.


### PR DESCRIPTION
Makes the `bind`, `inherit`, ect. methods return an `&'this mut Active` instead of an `Active<'this>`.
The reasons for this are primarily ergonomic. This now allows for a bind and state changes to be method-chained while still capturing the activation token. This is especially useful with vertex buffers.
Before:
```rust
// Attempting to chain all of this results in "temporary dropped while borrowed,"
// so you must make an intermediate variable binding:
let active_framebuffer = gl.framebuffer.draw.bind_default();
active_framebuffer
    .draw_buffers(&[])
    .clear(AspectMask::DEPTH);
// ... use `active_framebuffer`  further
```
After:
```rust
// Nice :3
let active_framebuffer = gl
    .framebuffer
    .draw
    .bind_default()
    .draw_buffers(&[])
    .clear(AspectMask::DEPTH);
// ... use `active_framebuffer` further
```
Also, only allows state mutation when `&mut self` is available, for ease of reasoning about who can mutate internal state from where. This is not totally complete, there are still many kinds of "interior mutability" available in the GL api that are not captured - like drawing to a framebuffer mutating the contents of attached images even though they're attached by const ref. This is not a soundness issue, merely a logical inconsistency that the user will just have to deal with, lol :P