### PR TITLE
`mint` support!

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,6 +393,7 @@ dependencies = [
  "gl_generator",
  "glutin",
  "glutin-winit",
+ "mint",
  "ultraviolet",
  "winit",
 ]
@@ -584,6 +585,12 @@ checksum = "fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "mint"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e53debba6bda7a793e5f99b8dacf19e626084f525f7829104ba9898f367d85ff"
 
 [[package]]
 name = "ndk"
@@ -1194,6 +1201,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a28554d13eb5daba527cc1b91b6c341372a0ae45ed277ffb2c6fbc04f319d7e"
 dependencies = [
  "bytemuck",
+ "mint",
  "wide",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,9 +5,11 @@ edition = "2021"
 
 [lib]
 
+
 [dependencies]
 bitflags = { version = "2.6.0" }
 bytemuck = { version = "1.16.1", features = ["derive"] }
+mint = {version = "0.5.9", optional = true }
 
 [build-dependencies]
 gl_generator = "0.14.0"
@@ -15,10 +17,15 @@ gl_generator = "0.14.0"
 [features]
 default = ["alloc"]
 alloc = []
+mint = ["dep:mint"]
 
 [dev-dependencies]
 anyhow = "1.0.86"
 glutin = "0.32.0"
 glutin-winit = "0.5.0"
-ultraviolet = { version = "0.9.2", features = ["bytemuck"] }
+ultraviolet = { version = "0.9.2", features = ["bytemuck", "mint"] }
 winit = "0.30.4"
+
+[[example]]
+name = "shadow-map"
+required-features = ["mint"]

--- a/examples/shadow-map/main.rs
+++ b/examples/shadow-map/main.rs
@@ -487,22 +487,15 @@ impl Window {
             proj * funnier_rotate * (rotate * translate)
         };
 
-        // Convert ultraviolet matrices into GLHF matrices.
-        let camera_matrix = glhf::program::uniform::Mat4::from(
-            camera_matrix.as_component_array().map(|v| *v.as_array()),
-        );
-        let shadow_matrix = glhf::program::uniform::Mat4::from(
-            shadow_matrix.as_component_array().map(|v| *v.as_array()),
-        );
         Self::err();
 
         // In our main program...
         gl.program
             .bind(&program)
             // Bind the matrices we just calculated!
-            .uniform_matrix(0, &camera_matrix)
+            .uniform_matrix(0, &mint::ColumnMatrix4::from(camera_matrix))
             // Note the location here - matrices take up many uniform slots.
-            .uniform_matrix(4, &shadow_matrix)
+            .uniform_matrix(4, &mint::ColumnMatrix4::from(shadow_matrix))
             // Bind texture unit 0, where we'll put the shadow texture at
             // draw time.
             .uniform(8, &0i32);
@@ -510,7 +503,7 @@ impl Window {
         // The shadow program only needs the sun matrix.
         gl.program
             .bind(&shadow_program)
-            .uniform_matrix(0, &shadow_matrix);
+            .uniform_matrix(0, &mint::ColumnMatrix4::from(shadow_matrix));
 
         // Load a test scene.
         let (vertices, indices) =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,11 @@
 //! * **`alloc` (default)**
 //! > Enables functions that involve `glGet`ting `CStrings`, such as program linker logs.
 //! > without this feature, the user must manually invoke the relavent GL calls.
+//! * **`mint`**
+//! > Enables easy use of linear algebra crates with program uniforms by implementing
+//! > `From<mint::ColumnMatrix*<f32>> for Matrix`. Note that `mint` uses the transpose of
+//! > the matrix size notation used by GL - a GLSL `mat4x3` is represented in mint by
+//! > `ColumnMatrix3x4`.
 //!
 //! This crate is `no_std` by default.
 

--- a/src/slot/program.rs
+++ b/src/slot/program.rs
@@ -264,6 +264,14 @@ impl Active<NotDefault> {
                     s.as_ptr().cast(),
                 );
             },
+            Matrix::Mat4x2(s) => unsafe {
+                gl::UniformMatrix4x2fv(
+                    location,
+                    s.len().try_into().unwrap(),
+                    gl::FALSE,
+                    s.as_ptr().cast(),
+                );
+            },
         }
         self
     }


### PR DESCRIPTION
Implements `From<&mint matrix ty> for Matrix` and `From<mint matrix ty> for Mat`, behind non-default-feature `mint`.
This removes the verbose round-trip from whatever math library you use to the corresponding `glhf` matrix type. The syntax leaves a lot to be desired, as `IntoMint` doesn't have an associated fn to perform the conversion, instead the whole type must be named :V